### PR TITLE
Refactor a `{% if exists("kind") and kind != "page" %}` into two if blocks

### DIFF
--- a/src/Doxybook/DefaultTemplates.cpp
+++ b/src/Doxybook/DefaultTemplates.cpp
@@ -18,7 +18,7 @@ static const std::string TEMPLATE_HEADER =
 {% include "meta" %}
 ---
 
-{% if exists("title") %}# {{title}}{% else if exists("kind") and kind != "page" %}# {{name}} {{title(kind)}} Reference{% endif %}
+{% if exists("title") %}# {{title}}{% else if exists("kind") %}{% if kind != "page" %}# {{name}} {{title(kind)}} Reference{% endif %}{% endif %}
 )";
 
 static const std::string TEMPLATE_BREADCRUMBS =


### PR DESCRIPTION
It appears that inja doesn't support lazy evaluation; if "kind" doesn't exist, then you'll get an error because the second part of the condition expects it to exist. I ran into this in a few other places in custom templates we wrote.