### PR TITLE
Turn off static linking of the Standard Library when compiling in debug mode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ set(CMAKE_MODULE_PATH
 
 project(Doxybook2)
 
-if(APPLE OR MSVC)
+if(APPLE OR MSVC OR CMAKE_BUILD_TYPE STREQUAL "Debug")
   set(DOXYBOOK_STATIC_STDLIB OFF)
 else()
   option(DOXYBOOK_STATIC_STDLIB "Use static stdlib" ON)


### PR DESCRIPTION
Static linking will disable GDB pretty printers for Standard Library data structures, which makes debugging a bit harder.