### PR TITLE
Prefer linking to entities in groups instead of entities in namespaces

### DIFF
--- a/src/Doxybook/JsonConverter.cpp
+++ b/src/Doxybook/JsonConverter.cpp
@@ -263,23 +263,25 @@ nlohmann::json Doxybook2::JsonConverter::getAsJson(const Node& node) const {
     nlohmann::json json = convert(node);
     nlohmann::json dataJson = convert(node, data);
     json.insert(dataJson.begin(), dataJson.end());
-    if (node.getParent()->getKind() != Kind::INDEX) {
-        std::list<const Node*> list;
-        auto parent = node.getParent();
-        while (parent != nullptr) {
-            list.push_front(parent);
-            parent = parent->getParent();
-            if (parent && parent->getKind() == Kind::INDEX)
-                parent = nullptr;
+    if (node.getParent() != nullptr) {
+        if (node.getParent()->getKind() != Kind::INDEX) {
+            std::list<const Node*> list;
+            auto parent = node.getParent();
+            while (parent != nullptr) {
+                list.push_front(parent);
+                parent = parent->getParent();
+                if (parent && parent->getKind() == Kind::INDEX)
+                    parent = nullptr;
+            }
+            nlohmann::json breadcrumbs = nlohmann::json::array();
+            for (const auto& ptr : list) {
+                breadcrumbs.push_back(convert(*ptr));
+            }
+            json["parentBreadcrumbs"] = std::move(breadcrumbs);
+            json["parent"] = convert(*node.getParent());
+        } else {
+            json["parent"] = nullptr;
         }
-        nlohmann::json breadcrumbs = nlohmann::json::array();
-        for (const auto& ptr : list) {
-            breadcrumbs.push_back(convert(*ptr));
-        }
-        json["parentBreadcrumbs"] = std::move(breadcrumbs);
-        json["parent"] = convert(*node.getParent());
-    } else {
-        json["parent"] = nullptr;
     }
 
     if (node.getGroup() != nullptr) {


### PR DESCRIPTION
Make sure to load basic information from groups first, so that when the same entity appears in both a group and a namespace, the link map points to the group reference not the namespace reference. This mirrors what Doxygen's HTML output does.

For example, one of my classes has a member function with a Doxygen `\see` comment that references a function which is in a group.

In the Doxygen XML, this reference appears as:

````
<simplesect kind="see"><para><ref refid="group__memory__management_1ga6a56463dcea00aaefa0371f80a462f4e" kindref="member">device_new</ref></para>
```

The corresponding `memberdef` for that ref appears in two places in the Doxygen XML output for my project:

* `namespacethrust.xml`
* `group__memory__mangement.xml`

In the Doxygen HTML output for `device_ptr`, the link for `device_new` goes to the group page, not the namespace page. But in Doxybook, it goes to the namespace page, not the group page.

This happens because `namespacethrust.xml` gets loaded first and its `memberdef` for `device_new` gets added to the unordered map of links first.

By loading basic info from all groups first, we ensure that links to an entity will point to a group page if they're in one before a namespace page.