### PR TITLE
Windows Arch Typo?

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,14 +21,14 @@ jobs:
             os: windows-latest
             triplet: x64-windows
             vcpkg_dir: 'C:\vcpkg'
-            suffix: 'windows-win32'
+            suffix: 'windows-win64'
             generator: 'Visual Studio 16 2019'
             arch: '-A x64'
           - name: 'Windows x86'
             os: windows-latest
             triplet: x86-windows
             vcpkg_dir: 'C:\vcpkg'
-            suffix: 'windows-win64'
+            suffix: 'windows-win32'
             generator: 'Visual Studio 16 2019'
             arch: '-A Win32'
           - name: 'Linux x64'


### PR DESCRIPTION
Looks like there is a typo in the workflow file. The windows Arch are the wrong way around