### PR TITLE
Add a `noop` Inja callback for whitespace trimming

### DIFF
--- a/src/Doxybook/Renderer.cpp
+++ b/src/Doxybook/Renderer.cpp
@@ -165,6 +165,7 @@ Doxybook2::Renderer::Renderer(const Config& config, const std::optional<std::str
         }
         return str;
     });
+    env->add_void_callback("noop", 0, [](inja::Arguments& args) {});
     // env->set_trim_blocks(false);
     // env->set_lstrip_blocks(false);
 


### PR DESCRIPTION
This a no-op that can be used to insert Inja's whitespace trimming facilities in particular locations in templates.

For context, see:

* https://github.com/pantor/inja/issues/200
* https://github.com/pantor/inja/issues/201