### PR TITLE
Add an `extractQualifiedNameFromFunctionDefinition` Inja callback

### DIFF
--- a/include/Doxybook/Utils.hpp
+++ b/include/Doxybook/Utils.hpp
@@ -48,6 +48,7 @@ namespace Doxybook2 {
         extern std::string date(const std::string& format);
         extern std::string stripNamespace(const std::string& format);
         extern std::string stripAnchor(const std::string& str);
+        extern std::string extractQualifiedNameFromFunctionDefinition(const std::string& str);
         extern std::vector<std::string> split(const std::string& str, const std::string& delim);
         extern void createDirectory(const std::string& path);
     } // namespace Utils

--- a/src/Doxybook/Renderer.cpp
+++ b/src/Doxybook/Renderer.cpp
@@ -92,6 +92,10 @@ Doxybook2::Renderer::Renderer(const Config& config, const std::optional<std::str
         const auto arg = args.at(0)->get<std::string>();
         return Utils::stripNamespace(arg);
     });
+    env->add_callback("extractQualifiedNameFromFunctionDefinition", 1, [](inja::Arguments& args) -> std::string {
+        const auto arg = args.at(0)->get<std::string>();
+        return Utils::extractQualifiedNameFromFunctionDefinition(arg);
+    });
     env->add_callback("split", 2, [](inja::Arguments& args) -> nlohmann::json {
         const auto arg0 = args.at(0)->get<std::string>();
         const auto arg1 = args.at(1)->get<std::string>();

--- a/src/Doxybook/Utils.cpp
+++ b/src/Doxybook/Utils.cpp
@@ -13,8 +13,6 @@
 #include <Doxybook/Utils.hpp>
 #include "ExceptionUtils.hpp"
 
-static const std::regex ANCHOR_REGEX("_[a-z0-9]{34,67}$");
-
 static std::string replaceAll(std::string str, const std::string& from, const std::string& to) {
     size_t pos = 0;
     while ((pos = str.find(from, pos)) != std::string::npos) {
@@ -84,10 +82,24 @@ std::string Doxybook2::Utils::stripNamespace(const std::string& str) {
     }
 }
 
+static const std::regex ANCHOR_REGEX(R"(_[a-z0-9]{34,67}$)");
+
 std::string Doxybook2::Utils::stripAnchor(const std::string& str) {
     std::stringstream ss;
     std::regex_replace(std::ostreambuf_iterator<char>(ss), str.begin(), str.end(), ANCHOR_REGEX, "");
     return ss.str();
+}
+
+static const std::regex FUNCTION_DEFINITION_REGEX(R"(^.* ([a-zA-Z0-9_::+*/%^&|~!=<>()\[\],-]+)$)");
+
+std::string Doxybook2::Utils::extractQualifiedNameFromFunctionDefinition(const std::string& str) {
+    std::smatch matches;
+    if (std::regex_match(str, matches, FUNCTION_DEFINITION_REGEX)) {
+        if (matches.size() == 2) {
+            return matches[1].str();
+        }
+    }
+    return str;
 }
 
 std::string Doxybook2::Utils::escape(std::string str) {


### PR DESCRIPTION
Doxygen sadly does not provide the fully qualified names of many things. However, for functions, it's fairly straightforward to parse the full qualified name out of the Doxygen function definition field, which is what this callback does.