### PR TITLE
Default templates: Ensure newline after brief when there is no detailed description.

### DIFF
--- a/src/Doxybook/DefaultTemplates.cpp
+++ b/src/Doxybook/DefaultTemplates.cpp
@@ -809,9 +809,7 @@ static const std::string TEMPLATE_KIND_NONCLASS =
 
 {% include "breadcrumbs" -%}
 
-{% if exists("brief") %}{{brief}}{% endif %}{% if hasDetails %} [More...](#detailed-description)
-
-{% endif -%}
+{% if exists("brief") %}{{brief}}{% endif %}{% if hasDetails %} [More...](#detailed-description){% endif %}
 
 {% include "nonclass_members_tables" -%}
 
@@ -828,9 +826,7 @@ static const std::string TEMPLATE_KIND_CLASS =
 
 {% include "breadcrumbs" %}
 
-{% if exists("brief") %}{{brief}}{% endif %}{% if hasDetails %} [More...](#detailed-description)
-
-{% endif -%}
+{% if exists("brief") %}{{brief}}{% endif %}{% if hasDetails %} [More...](#detailed-description){% endif %}
 
 {% if exists("includes") %}
 `#include {{includes}}`
@@ -870,9 +866,7 @@ static const std::string TEMPLATE_KIND_GROUP =
 
 {% include "breadcrumbs" -%}
 
-{% if exists("brief") %}{{brief}}{% endif %}{% if hasDetails %} [More...](#detailed-description)
-
-{% endif -%}
+{% if exists("brief") %}{{brief}}{% endif %}{% if hasDetails %} [More...](#detailed-description){% endif %}
 
 {% include "nonclass_members_tables" -%}
 
@@ -888,9 +882,7 @@ static const std::string TEMPLATE_KIND_GROUP =
 static const std::string TEMPLATE_KIND_FILE =
     R"({% include "header" -%}
 
-{% if exists("brief") %}{{brief}}{% endif %}{% if hasDetails %} [More...](#detailed-description)
-
-{% endif -%}
+{% if exists("brief") %}{{brief}}{% endif %}{% if hasDetails %} [More...](#detailed-description){% endif %}
 
 {% include "nonclass_members_tables" -%}
 


### PR DESCRIPTION
I noticed that the current default templates will not always separate the brief description and the following section (e.g. `## Classes`) when there is no detailed description for an entity.

Example:

Doxygen comment:
```cpp
// error.h
/**
 * \file
 * \brief Basic error handling facilities.
 */
```

Current output (version 1.3.5), note the misplaced `## Types`:
```markdown
# error.h

Basic error handling facilities. ## Types
```
Output after commit:
```markdown
# error.h

Basic error handling facilities. 

## Types
```
The output in other cases seems to be reasonable as well.