### PR TITLE
Fix "=delete" not appearing in doxybook2 output.

### DIFF
--- a/src/Doxybook/DefaultTemplates.cpp
+++ b/src/Doxybook/DefaultTemplates.cpp
@@ -452,7 +452,7 @@ static std::string createTableForFunctionLike(const std::string& visibility,
     ss << "{% if child.const %} const{% endif -%}\n";
     ss << "{% if child.override %} override{% endif -%}\n";
     ss << "{% if child.default %} =default{% endif -%}\n";
-    ss << "{% if child.deleted %} =deleted{% endif -%}\n";
+    ss << "{% if child.deleted %} =delete{% endif -%}\n";
     ss << "{% if child.pureVirtual %} =0{% endif -%}\n";
 
     ss << " {% if existsIn(child, \"brief\") %}<br>{{child.brief}}{% endif %} |\n";
@@ -609,7 +609,7 @@ template <{% for param in templateParams %}{{param.typePlain}} {{param.name}}{% 
 {% if const %} const{% endif -%}
 {% if override %} override{% endif -%}
 {% if default %} =default{% endif -%}
-{% if deleted %} =deleted{% endif -%}
+{% if deleted %} =delete{% endif -%}
 {% if pureVirtual %} =0{% endif %}
 ```{% endif -%}
 

--- a/src/Doxybook/Node.cpp
+++ b/src/Doxybook/Node.cpp
@@ -436,7 +436,7 @@ Doxybook2::Node::Data Doxybook2::Node::loadData(const Config& config,
     if (argsstring) {
         data.argsString = markdownPrinter.print(XmlTextParser::parsePara(argsstring));
         data.isDefault = data.argsString.find("=default") != std::string::npos;
-        data.isDeleted = data.argsString.find("=deleted") != std::string::npos;
+        data.isDeleted = data.argsString.find("=delete") != std::string::npos;
         data.isOverride = data.argsString.find(" override") != std::string::npos;
     }
 


### PR DESCRIPTION
doxybook2 currently does not mark functions correctly as deleted, if done so with "=delete", due to a small typo.

This PR fixes the typo, however only in in- and output of doxybook2. I'll leave it up to you if you also want to refactor the internal code that also uses "deleted" instead of "delete".