### PR TITLE
Make date string locale independent

### DIFF
--- a/src/Doxybook/DefaultTemplates.cpp
+++ b/src/Doxybook/DefaultTemplates.cpp
@@ -41,7 +41,7 @@ static const std::string TEMPLATE_BREADCRUMBS = R"({% if exists("moduleBreadcrum
 static const std::string TEMPLATE_FOOTER =
     R"(-------------------------------
 
-Updated on {{date("%e %B %Y at %H:%M:%S %Z")}})";
+Updated on {{date("%F at %H:%M:%S %z")}})";
 
 static const std::string TEMPLATE_DETAILS =
     R"({% if exists("brief") %}{{brief}}


### PR DESCRIPTION
I came across an issue where mkDocs was unable to process the generated .md files due to invalid UTF-8 characters in the locale dependent Timezone name (%Z) (html footer), see: http://www.cplusplus.com/reference/ctime/strftime/

So I propose to make the date string locale independent.

This will output something like:

`Updated on 2021-08-18 at 21:38:36 +0200`

instead of (german):

`Updated on 18 August 2021 at 21:38:36 Mitteleurop�ische Sommerzeit`