### PR TITLE
Add basic Java support

### DIFF
--- a/include/Doxybook/Config.hpp
+++ b/include/Doxybook/Config.hpp
@@ -69,6 +69,7 @@ namespace Doxybook2 {
         std::string templateKindStruct{"kind_class"};
         std::string templateKindUnion{"kind_class"};
         std::string templateKindInterface{"kind_class"};
+        std::string templateKindJavaEnum{"kind_class"};
         std::string templateKindNamespace{"kind_nonclass"};
         std::string templateKindGroup{"kind_nonclass"};
         std::string templateKindFile{"kind_file"};

--- a/include/Doxybook/Enums.hpp
+++ b/include/Doxybook/Enums.hpp
@@ -28,7 +28,9 @@ namespace Doxybook2 {
         SIGNAL,
         SLOT,
         PROPERTY,
-        EVENT
+        EVENT,
+        JAVAENUM,
+        JAVAENUMCONSTANT
     };
 
     enum class Visibility { PUBLIC, PROTECTED, PRIVATE, PACKAGE };
@@ -52,22 +54,28 @@ namespace Doxybook2 {
         SIGNALS,
         SLOTS,
         EVENTS,
-        PROPERTIES
+        PROPERTIES,
+        JAVAENUMCONSTANTS
     };
 
     enum class FolderCategory { CLASSES, NAMESPACES, MODULES, PAGES, FILES, EXAMPLES };
+
+    enum class Language { CPP, JAVA };
 
     extern Kind toEnumKind(const std::string& str);
     extern Type toEnumType(const std::string& str);
     extern Visibility toEnumVisibility(const std::string& str);
     extern Virtual toEnumVirtual(const std::string& str);
     extern FolderCategory toEnumFolderCategory(const std::string& str);
+    extern Language toEnumLanguage(const std::string& str);
 
     extern std::string toStr(Kind value);
     extern std::string toStr(Type value);
     extern std::string toStr(Visibility value);
     extern std::string toStr(Virtual value);
     extern std::string toStr(FolderCategory value);
+    extern std::string toStr(const Language value);
+
 
     extern Type kindToType(Kind kind);
 

--- a/include/Doxybook/Node.hpp
+++ b/include/Doxybook/Node.hpp
@@ -143,6 +143,10 @@ namespace Doxybook2 {
             return type;
         }
 
+        Language getLanguage() const {
+            return language;
+        }
+
         const std::string& getRefid() const {
             return refid;
         }
@@ -231,6 +235,7 @@ namespace Doxybook2 {
         std::unique_ptr<Temp> temp;
         Kind kind{Kind::INDEX};
         Type type{Type::NONE};
+        Language language{Language::CPP};
         std::string refid;
         std::string name;
         std::string brief;

--- a/include/Doxybook/Utils.hpp
+++ b/include/Doxybook/Utils.hpp
@@ -45,6 +45,7 @@ namespace Doxybook2 {
         extern std::string title(std::string str);
         extern std::string toLower(std::string str);
         extern std::string safeAnchorId(std::string str);
+        extern std::string namespaceToPackage(std::string str);
         extern std::string date(const std::string& format);
         extern std::string stripNamespace(const std::string& format);
         extern std::string stripAnchor(const std::string& str);

--- a/src/Doxybook/Generator.cpp
+++ b/src/Doxybook/Generator.cpp
@@ -32,6 +32,8 @@ std::string Doxybook2::Generator::kindToTemplateName(const Kind kind) {
             return config.templateKindPage;
         case Kind::EXAMPLE:
             return config.templateKindExample;
+        case Kind::JAVAENUM:
+            return config.templateKindJavaEnum;
         default: {
             throw EXCEPTION("Unrecognised kind {} please contant the author!", int(kind));
         }

--- a/src/Doxybook/JsonConverter.cpp
+++ b/src/Doxybook/JsonConverter.cpp
@@ -115,12 +115,25 @@ nlohmann::json Doxybook2::JsonConverter::convert(const Node& node) const {
         json["brief"] = node.getBrief();
     if (!node.getSummary().empty())
         json["summary"] = node.getSummary();
+    json["language"] = toStr(node.getLanguage());
     json["kind"] = toStr(node.getKind());
     json["category"] = toStr(node.getType());
     if (!node.getBaseClasses().empty())
         json["baseClasses"] = convert(node.getBaseClasses());
     if (!node.getDerivedClasses().empty())
         json["derivedClasses"] = convert(node.getDerivedClasses());
+
+    // language specific fixups
+    if (node.getLanguage() == Language::JAVA)
+    {
+        json["name"] = Utils::namespaceToPackage(json["name"]);
+        json["fullname"] = Utils::namespaceToPackage(json["fullname"]);
+        json["title"] = Utils::namespaceToPackage(json["title"]);
+
+        if (node.getKind() == Kind::NAMESPACE)
+            json["kind"] = "package";
+    }
+
     return json;
 }
 

--- a/src/Doxybook/Node.cpp
+++ b/src/Doxybook/Node.cpp
@@ -87,7 +87,8 @@ Doxybook2::Node::parse(NodeCacheMap& cache, const std::string& inputDir, const N
             child->language = ptr->language;
 
             // Doxygen outputs Java enum values as variables with empty <type>
-            bool hasTypeDefined = memberdef.firstChildElement("type").hasText();
+            auto typeElement = memberdef.firstChildElement("type");
+            bool hasTypeDefined = typeElement ? typeElement.hasText() : false;
             if (ptr->kind == Kind::JAVAENUM && child->kind == Kind::VARIABLE && !hasTypeDefined)
             {
                 child->kind = Kind::JAVAENUMCONSTANT;

--- a/src/Doxybook/Utils.cpp
+++ b/src/Doxybook/Utils.cpp
@@ -38,6 +38,10 @@ std::string Doxybook2::Utils::safeAnchorId(std::string str) {
     return replaceAll(replaceAll(toLower(std::move(str)), "::", ""), " ", "-");
 }
 
+std::string Doxybook2::Utils::namespaceToPackage(std::string str) {
+    return replaceAll(std::move(str), "::", ".");
+}
+
 std::string Doxybook2::Utils::date(const std::string& format) {
     const auto t = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
     char mbstr[100];
@@ -63,6 +67,7 @@ std::string Doxybook2::Utils::stripNamespace(const std::string& str) {
                 inside--;
                 break;
             }
+            case '.':
             case ':': {
                 if (inside == 0) {
                     offset = count + 1;

--- a/src/DoxybookCli/main.cpp
+++ b/src/DoxybookCli/main.cpp
@@ -58,7 +58,8 @@ static const Generator::Filter INDEX_CLASS_FILTER = {Kind::NAMESPACE,
     Kind::CLASS,
     Kind::INTERFACE,
     Kind::STRUCT,
-    Kind::UNION};
+    Kind::UNION,
+    Kind::JAVAENUM};
 
 static const Generator::Filter INDEX_CLASS_FILTER_SKIP = {Kind::NAMESPACE};
 
@@ -69,7 +70,7 @@ static const Generator::Filter INDEX_MODULES_FILTER = {Kind::MODULE};
 static const Generator::Filter INDEX_FILES_FILTER = {Kind::DIR, Kind::FILE};
 
 static const Generator::Filter LANGUAGE_FILTER =
-    {Kind::NAMESPACE, Kind::CLASS, Kind::INTERFACE, Kind::STRUCT, Kind::UNION, Kind::MODULE};
+    {Kind::NAMESPACE, Kind::CLASS, Kind::INTERFACE, Kind::STRUCT, Kind::UNION, Kind::MODULE, Kind::JAVAENUM};
 
 static const Generator::Filter INDEX_PAGES_FILTER = {Kind::PAGE};
 
@@ -218,6 +219,7 @@ int main(const int argc, char* argv[]) {
                     languageFilder.insert(Kind::STRUCT);
                     languageFilder.insert(Kind::UNION);
                     languageFilder.insert(Kind::INTERFACE);
+                    languageFilder.insert(Kind::JAVAENUM);
                 }
                 if (shouldGenerate(FolderCategory::NAMESPACES)) {
                     languageFilder.insert(Kind::NAMESPACE);


### PR DESCRIPTION
## Background
I wanted to use Doxybook2 for documenting Java code, but it crashed with an unhandled exception. The reason for this is enums in Java are different from C++ counterparts. They behave more like classes: they have methods and variables. Doxygen emits a separate xml for them similarly to classes (unlike c++ enums, which are embedded in containing scope xmls). Enum constants (enumerators) are listed as member variables without an associated &lt;type&gt;.

## PR contents:
- Add language as enum to Node, use it in markdown fenced code blocks
- Add JAVAENUM kind as structured kind behaving like classes
- Add JAVAENUMCONSTANT kind to disambiguate variables and enumerators
- Add JAVAENUMCONSTANTS type so enum constants appear under a separate chapter in the class template
- Update templates to display java enum documentation
- Few java specific fixups: namespace(::)->package(.), `interface` keyword exists, `inline` does not

