### PR TITLE
Basic Java support

### DIFF
--- a/include/Doxybook/Config.hpp
+++ b/include/Doxybook/Config.hpp
@@ -69,6 +69,7 @@ namespace Doxybook2 {
         std::string templateKindStruct{"kind_class"};
         std::string templateKindUnion{"kind_class"};
         std::string templateKindInterface{"kind_class"};
+        std::string templateKindJavaEnum{"kind_class"};
         std::string templateKindNamespace{"kind_nonclass"};
         std::string templateKindGroup{"kind_nonclass"};
         std::string templateKindFile{"kind_file"};

--- a/include/Doxybook/Enums.hpp
+++ b/include/Doxybook/Enums.hpp
@@ -28,7 +28,9 @@ namespace Doxybook2 {
         SIGNAL,
         SLOT,
         PROPERTY,
-        EVENT
+        EVENT,
+        JAVAENUM,
+        JAVAENUMCONSTANT
     };
 
     enum class Visibility { PUBLIC, PROTECTED, PRIVATE, PACKAGE };
@@ -52,7 +54,8 @@ namespace Doxybook2 {
         SIGNALS,
         SLOTS,
         EVENTS,
-        PROPERTIES
+        PROPERTIES,
+        JAVAENUMCONSTANTS
     };
 
     enum class FolderCategory { CLASSES, NAMESPACES, MODULES, PAGES, FILES, EXAMPLES };
@@ -68,6 +71,7 @@ namespace Doxybook2 {
     extern std::string toStr(Visibility value);
     extern std::string toStr(Virtual value);
     extern std::string toStr(FolderCategory value);
+
 
     extern Type kindToType(Kind kind);
 

--- a/include/Doxybook/Utils.hpp
+++ b/include/Doxybook/Utils.hpp
@@ -46,6 +46,7 @@ namespace Doxybook2 {
         extern std::string title(std::string str);
         extern std::string toLower(std::string str);
         extern std::string safeAnchorId(std::string str);
+        extern std::string namespaceToPackage(std::string str);
         extern std::string date(const std::string& format);
         extern std::string stripNamespace(const std::string& format);
         extern std::string stripAnchor(const std::string& str);

--- a/src/Doxybook/DefaultTemplates.cpp
+++ b/src/Doxybook/DefaultTemplates.cpp
@@ -372,6 +372,7 @@ static std::string createTableForAttributeLike(const std::string& visibility,
     ss << "| -------------- | -------------- |\n";
 
     ss << "{% for child in " << (inherited ? "base." : "") << key << " -%}\n";
+
     ss << "| {% if existsIn(child, \"type\") %}{{child.type}} {% endif -%}\n";
     ss << "| **[{{child.name}}]({{child.url}})**";
     ss << " {% if existsIn(child, \"brief\") %}<br>{{child.brief}}{% endif %} |\n";

--- a/src/Doxybook/Enums.cpp
+++ b/src/Doxybook/Enums.cpp
@@ -32,7 +32,9 @@ static const std::vector<KindStrPair> KIND_STRS = {
     {"slot", Doxybook2::Kind::SLOT},
     {"property", Doxybook2::Kind::PROPERTY},
     {"event", Doxybook2::Kind::EVENT},
-    {"define", Doxybook2::Kind::DEFINE}
+    {"define", Doxybook2::Kind::DEFINE},
+    {"enum", Doxybook2::Kind::JAVAENUM},                  // only for enum->string conversion
+    {"enum constant", Doxybook2::Kind::JAVAENUMCONSTANT}  // only for enum->string conversion
 };
 
 static const std::vector<TypeStrPair> TYPE_STRS = {
@@ -51,7 +53,8 @@ static const std::vector<TypeStrPair> TYPE_STRS = {
     {"signals", Doxybook2::Type::SIGNALS},
     {"slots", Doxybook2::Type::SLOTS},
     {"events", Doxybook2::Type::EVENTS},
-    {"properties", Doxybook2::Type::PROPERTIES}
+    {"properties", Doxybook2::Type::PROPERTIES},
+    {"javaenumconstants", Doxybook2::Type::JAVAENUMCONSTANTS}
 };
 
 static const std::vector<VirtualStrPair> VIRTUAL_STRS = {
@@ -180,7 +183,8 @@ Doxybook2::Type Doxybook2::kindToType(const Doxybook2::Kind kind) {
         case Kind::UNION:
         case Kind::INTERFACE:
         case Kind::STRUCT:
-        case Kind::CLASS: {
+        case Kind::CLASS:
+        case Kind::JAVAENUM: {
             return Type::CLASSES;
         }
         case Kind::FILE: {
@@ -220,6 +224,7 @@ bool Doxybook2::isKindStructured(const Kind kind) {
         case Doxybook2::Kind::NAMESPACE:
         case Doxybook2::Kind::STRUCT:
         case Doxybook2::Kind::UNION:
+        case Doxybook2::Kind::JAVAENUM:
         case Doxybook2::Kind::INTERFACE: {
             return true;
         }
@@ -246,7 +251,9 @@ bool Doxybook2::isKindLanguage(const Kind kind) {
         case Doxybook2::Kind::SIGNAL:
         case Doxybook2::Kind::SLOT:
         case Doxybook2::Kind::PROPERTY:
-        case Doxybook2::Kind::EVENT: {
+        case Doxybook2::Kind::EVENT:
+        case Doxybook2::Kind::JAVAENUM:
+        case Doxybook2::Kind::JAVAENUMCONSTANT: {
             return true;
         }
         default: {

--- a/src/Doxybook/Generator.cpp
+++ b/src/Doxybook/Generator.cpp
@@ -33,6 +33,8 @@ std::string Doxybook2::Generator::kindToTemplateName(const Kind kind) {
             return config.templateKindPage;
         case Kind::EXAMPLE:
             return config.templateKindExample;
+        case Kind::JAVAENUM:
+            return config.templateKindJavaEnum;
         default: {
             throw EXCEPTION("Unrecognised kind {} please contant the author!", int(kind));
         }

--- a/src/Doxybook/JsonConverter.cpp
+++ b/src/Doxybook/JsonConverter.cpp
@@ -115,6 +115,7 @@ nlohmann::json Doxybook2::JsonConverter::convert(const Node& node) const {
         json["brief"] = Utils::replaceNewline(node.getBrief());
     if (!node.getSummary().empty())
         json["summary"] = node.getSummary();
+    json["language"] = node.getLanguage();
     json["kind"] = toStr(node.getKind());
     json["language"] = node.getLanguage();
     json["category"] = toStr(node.getType());
@@ -122,6 +123,18 @@ nlohmann::json Doxybook2::JsonConverter::convert(const Node& node) const {
         json["baseClasses"] = convert(node.getBaseClasses());
     if (!node.getDerivedClasses().empty())
         json["derivedClasses"] = convert(node.getDerivedClasses());
+
+    // language specific fixups
+    if (node.getLanguage() == "java")
+    {
+        json["name"] = Utils::namespaceToPackage(json["name"]);
+        json["fullname"] = Utils::namespaceToPackage(json["fullname"]);
+        json["title"] = Utils::namespaceToPackage(json["title"]);
+
+        if (node.getKind() == Kind::NAMESPACE)
+            json["kind"] = "package";
+    }
+
     return json;
 }
 

--- a/src/Doxybook/Node.cpp
+++ b/src/Doxybook/Node.cpp
@@ -61,8 +61,10 @@ Doxybook2::Node::parse(NodeCacheMap& cache, const std::string& inputDir, const N
 
     ptr->xmlPath = refidPath;
     ptr->name = assertChild(compounddef, "compoundname").getText();
-    ptr->kind = toEnumKind(compounddef.getAttr("kind"));
     ptr->language = Utils::normalizeLanguage(compounddef.getAttr("language", ""));
+    auto kind = toEnumKind(compounddef.getAttr("kind"));
+    ptr->kind = (ptr->language == "java" && kind == Kind::ENUM) ? Kind::JAVAENUM
+                                                                : kind;
     ptr->empty = false;
     cache.insert(std::make_pair(ptr->refid, ptr));
 
@@ -71,7 +73,6 @@ Doxybook2::Node::parse(NodeCacheMap& cache, const std::string& inputDir, const N
     while (sectiondef) {
         auto memberdef = sectiondef.firstChildElement("memberdef");
         while (memberdef) {
-            const auto childKindStr = memberdef.getAttr("kind");
             const auto childRefid = memberdef.getAttr("id");
             const auto found = findInCache(cache, childRefid);
             const auto child = found ? found : Node::parse(memberdef, childRefid);
@@ -83,6 +84,16 @@ Doxybook2::Node::parse(NodeCacheMap& cache, const std::string& inputDir, const N
                 }
             }
             child->language = ptr->language;
+
+            // Doxygen outputs Java enum values as variables with empty <type>
+            auto typeElement = memberdef.firstChildElement("type");
+            bool hasTypeDefined = typeElement ? typeElement.hasText() : false;
+            if (ptr->kind == Kind::JAVAENUM && child->kind == Kind::VARIABLE && !hasTypeDefined)
+            {
+                child->kind = Kind::JAVAENUMCONSTANT;
+                child->type = Type::JAVAENUMCONSTANTS;
+            }
+
             ptr->children.push_back(child);
 
             if (isGroupOrFile) {
@@ -246,7 +257,7 @@ void Doxybook2::Node::finalize(const Config& config,
 
     static const auto anchorMaker = [](const Node& node) {
         if (!node.isStructured() && node.kind != Kind::MODULE) {
-            return "#" + Utils::toLower(toStr(node.kind)) + "-" + Utils::safeAnchorId(node.name);
+            return Utils::safeAnchorId("#" + Utils::toLower(toStr(node.kind)) + "-" + node.name);
         } else {
             return std::string("");
         }
@@ -271,7 +282,8 @@ void Doxybook2::Node::finalize(const Config& config,
             case Kind::PAGE:
             case Kind::INTERFACE:
             case Kind::EXAMPLE:
-            case Kind::UNION: {
+            case Kind::UNION:
+            case Kind::JAVAENUM: {
                 if (node.refid == config.mainPageName) {
                     if (config.mainPageInRoot) {
                         return config.baseUrl;
@@ -396,7 +408,7 @@ Doxybook2::Node::LoadDataResult Doxybook2::Node::loadData(const Config& config,
     return {data, childrenData};
 }
 
-Doxybook2::Node::Data Doxybook2::Node::loadData(const Config& config,
+Doxybook2::Node::Data Doxybook2::Node::loadData(const Config& /*config*/,
     const TextPrinter& plainPrinter,
     const TextPrinter& markdownPrinter,
     const NodeCacheMap& cache,

--- a/src/Doxybook/Utils.cpp
+++ b/src/Doxybook/Utils.cpp
@@ -67,6 +67,10 @@ std::string Doxybook2::Utils::safeAnchorId(std::string str) {
     return replaceAll(str, "_", "-");
 }
 
+std::string Doxybook2::Utils::namespaceToPackage(std::string str) {
+    return replaceAll(std::move(str), "::", ".");
+}
+
 std::string Doxybook2::Utils::date(const std::string& format) {
     const auto t = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
     char mbstr[100];
@@ -92,6 +96,7 @@ std::string Doxybook2::Utils::stripNamespace(const std::string& str) {
                 inside--;
                 break;
             }
+            case '.':
             case ':': {
                 if (inside == 0) {
                     offset = count + 1;

--- a/src/DoxybookCli/main.cpp
+++ b/src/DoxybookCli/main.cpp
@@ -26,7 +26,8 @@ static const Generator::Filter INDEX_CLASS_FILTER = {Kind::NAMESPACE,
     Kind::CLASS,
     Kind::INTERFACE,
     Kind::STRUCT,
-    Kind::UNION};
+    Kind::UNION,
+    Kind::JAVAENUM};
 
 static const Generator::Filter INDEX_CLASS_FILTER_SKIP = {Kind::NAMESPACE};
 
@@ -37,7 +38,7 @@ static const Generator::Filter INDEX_MODULES_FILTER = {Kind::MODULE};
 static const Generator::Filter INDEX_FILES_FILTER = {Kind::DIR, Kind::FILE};
 
 static const Generator::Filter LANGUAGE_FILTER =
-    {Kind::NAMESPACE, Kind::CLASS, Kind::INTERFACE, Kind::STRUCT, Kind::UNION, Kind::MODULE};
+    {Kind::NAMESPACE, Kind::CLASS, Kind::INTERFACE, Kind::STRUCT, Kind::UNION, Kind::MODULE, Kind::JAVAENUM};
 
 static const Generator::Filter INDEX_PAGES_FILTER = {Kind::PAGE};
 
@@ -208,6 +209,7 @@ int main(int argc, char* argv[]) {
                     languageFilder.insert(Kind::STRUCT);
                     languageFilder.insert(Kind::UNION);
                     languageFilder.insert(Kind::INTERFACE);
+                    languageFilder.insert(Kind::JAVAENUM);
                 }
                 if (shouldGenerate(FolderCategory::NAMESPACES)) {
                     languageFilder.insert(Kind::NAMESPACE);


### PR DESCRIPTION
## Background
I wanted to use Doxybook2 for documenting Java code, but it crashed with an unhandled exception. The reason for this is enums in Java are different from C++ counterparts. They behave more like classes: they have methods and variables. Doxygen emits a separate xml for them similarly to classes (unlike c++ enums, which are embedded in containing scope xmls). Enum constants (enumerators) are listed as member variables without an associated &lt;type&gt;.

## PR contents:
- Add JAVAENUM kind as structured kind behaving like classes
- Add JAVAENUMCONSTANT kind to disambiguate variables and enumerators
- Add JAVAENUMCONSTANTS type so enum constants appear under a separate chapter in the class template
- Update templates to display java enum documentation
- Few java specific fixups: namespace(::)->package(.), `interface` keyword exists, `inline` does not