### PR TITLE
Append argsString to function pointer variables

### DIFF
--- a/src/Doxybook/Node.cpp
+++ b/src/Doxybook/Node.cpp
@@ -372,7 +372,7 @@ Doxybook2::Node::LoadDataResult Doxybook2::Node::loadData(const Config& config,
                                     loadData(config, plainPrinter, markdownPrinter, cache, memberdef)))
                                 .first;
 
-            if (childPtr->kind == Kind::TYPEDEF) {
+            if (childPtr->kind == Kind::TYPEDEF || childPtr->kind == Kind::VARIABLE) {
                 it->second.type += it->second.argsString;
                 it->second.typePlain += it->second.argsString;
             }
@@ -585,7 +585,7 @@ Doxybook2::Node::Data Doxybook2::Node::loadData(const Config& config,
             data.typePlain = data.typePlain.substr(7);
         }
 
-        if (this->kind == Kind::TYPEDEF) {
+        if (this->kind == Kind::TYPEDEF || this->kind == Kind::VARIABLE) {
             data.type += data.argsString;
             data.typePlain += data.argsString;
         }


### PR DESCRIPTION
Hi,

given a c-style struct definition such as this:

```c
typedef struct tiro_vm_settings {
    /**
     * docs..
     */
    void (*print_stdout)(tiro_string_t message, void* userdata);
} tiro_vm_settings_t;
```
Doxybook only prints a subset of the function pointer's actual type:

````markdown
### variable print_stdout

```cpp
 void(* print_stdout;
```
````

I saw your [old fix for typedefs](https://github.com/matusnovak/doxybook2/commit/9d393c26a68aee7abe9c046b8dff3595c2f35593) and adapted it to work on variables, too.

It now renders like this:


````markdown
### variable print_stdout

```cpp
void(*)(tiro_string_t message, void *userdata) print_stdout;
```
````