### PR TITLE
Expose `Utils::safeAnchorId` as an Inja callback.

### DIFF
--- a/src/Doxybook/Renderer.cpp
+++ b/src/Doxybook/Renderer.cpp
@@ -91,6 +91,10 @@ Doxybook2::Renderer::Renderer(const Config& config,
         const auto arg = args.at(0)->get<std::string>();
         return Utils::escape(arg);
     });
+    env->add_callback("safeAnchorId", 1, [](inja::Arguments& args) -> std::string {
+        const auto arg = args.at(0)->get<std::string>();
+        return Utils::safeAnchorId(arg);
+    });
     env->add_callback("title", 1, [](inja::Arguments& args) {
         const auto arg = args.at(0)->get<std::string>();
         return Utils::title(arg);


### PR DESCRIPTION
I needed this because we generate our own HTML anchor ids and need to match what Doxybook expects and fills in the JSON "url" fields with.