### PR TITLE
Use proposed new Doxygen `<qualifiedname>` metadata if it's available

### DIFF
--- a/include/Doxybook/Node.hpp
+++ b/include/Doxybook/Node.hpp
@@ -151,6 +151,10 @@ namespace Doxybook2 {
             return refid;
         }
 
+        const std::string& getQualifiedName() const {
+            return qualifiedName;
+        }
+
         const std::string& getName() const {
             return name;
         }
@@ -238,6 +242,7 @@ namespace Doxybook2 {
         std::string language;
         std::string refid;
         std::string name;
+        std::string qualifiedName;
         std::string brief;
         std::string summary;
         std::string title;

--- a/src/Doxybook/JsonConverter.cpp
+++ b/src/Doxybook/JsonConverter.cpp
@@ -95,6 +95,11 @@ nlohmann::json Doxybook2::JsonConverter::convert(const Node& node) const {
     } else {
         json["name"] = node.getName();
         json["title"] = node.getTitle();
+        if (node.getQualifiedName().empty()) {
+            json["qualifiedname"] = node.getName();
+        } else {
+            json["qualifiedname"] = node.getQualifiedName();
+        }
     }
     if (!node.isStructured() && node.getKind() != Kind::MODULE && node.getKind() != Kind::DEFINE &&
         node.getKind() != Kind::FILE && node.getKind() != Kind::DIR) {

--- a/src/Doxybook/Node.cpp
+++ b/src/Doxybook/Node.cpp
@@ -147,6 +147,14 @@ Doxybook2::NodePtr Doxybook2::Node::parse(Xml::Element& memberdef, const std::st
 
     auto ptr = std::make_shared<Node>(refid);
     ptr->name = assertChild(memberdef, "name").getText();
+
+    auto childQualifiedName = memberdef.firstChildElement("qualifiedname");
+    if (childQualifiedName) {
+        ptr->qualifiedName = childQualifiedName.getText();
+    } else {
+        ptr->qualifiedName = ptr->name;
+    }
+
     ptr->kind = toEnumKind(memberdef.getAttr("kind"));
     ptr->empty = true;
     ptr->parseBaseInfo(memberdef);

--- a/src/Doxybook/Renderer.cpp
+++ b/src/Doxybook/Renderer.cpp
@@ -36,7 +36,7 @@ static std::string trimPath(std::string path) {
 
 static std::string stripTmplSuffix(std::string path) {
     if (path.size() > 4 && path.find(".tmpl") == path.size() - 5) {
-        path.erase(path.size() - 5); 
+        path.erase(path.size() - 5);
     }
     return path;
 }
@@ -102,10 +102,6 @@ Doxybook2::Renderer::Renderer(const Config& config,
     env->add_callback("stripNamespace", 1, [](inja::Arguments& args) -> std::string {
         const auto arg = args.at(0)->get<std::string>();
         return Utils::stripNamespace(arg);
-    });
-    env->add_callback("extractQualifiedNameFromFunctionDefinition", 1, [](inja::Arguments& args) -> std::string {
-        const auto arg = args.at(0)->get<std::string>();
-        return Utils::extractQualifiedNameFromFunctionDefinition(arg);
     });
     env->add_callback("split", 2, [](inja::Arguments& args) -> nlohmann::json {
         const auto arg0 = args.at(0)->get<std::string>();

--- a/src/Doxybook/Utils.cpp
+++ b/src/Doxybook/Utils.cpp
@@ -119,18 +119,6 @@ std::string Doxybook2::Utils::stripAnchor(const std::string& str) {
     return ss.str();
 }
 
-static const std::regex FUNCTION_DEFINITION_REGEX(R"(^.* ([a-zA-Z0-9_::+*/%^&|~!=<>()\[\],-]+)$)");
-
-std::string Doxybook2::Utils::extractQualifiedNameFromFunctionDefinition(const std::string& str) {
-    std::smatch matches;
-    if (std::regex_match(str, matches, FUNCTION_DEFINITION_REGEX)) {
-        if (matches.size() == 2) {
-            return matches[1].str();
-        }
-    }
-    return str;
-}
-
 std::string Doxybook2::Utils::escape(std::string str) {
     size_t new_size = 0;
     for (const auto& c : str) {


### PR DESCRIPTION
Today, we're unable to get the fully qualified names of a wide variety of C++ entities that Doxygen models as members - functions, enums, typedefs, variables, etc. These things all appear in the Doxygen XML output as `<memberdef>`s and have a `<name>` child that contains a local unqualified name of the thing.

I've proposed in https://github.com/doxygen/doxygen/pull/8983 the addition of a `<qualifiedname>` child to `<memberdef>`s which would have the fully qualified name of the entity.

This PR adds support to Doxybook for parsing `<qualifiedname>` and adding `qualifiedname` entries to Doxybook's JSON output.

I've structured this change to not expect or require `<qualifiedname>` to exist. If an entity doesn't have a `<qualifiedname>` child in the Doxygen XML, then it's `qualifiedname` in the JSON output is equivalent to its `name`.

Today, Doxybook does construct a `fullname` for some entities, but this is different from a C++ qualified name - for example I believe the `fullname` of something in a group will be `group::name`, where `group` is just the name of the Doxygen group, NOT the actual C++ scope of the entity.