### PR TITLE
Fixed mapping of Doxygen sections to markdown headings

### DIFF
--- a/example/Doxyfile
+++ b/example/Doxyfile
@@ -8,7 +8,7 @@ GENERATE_XML = YES
 XML_OUTPUT = xml
 INPUT = src
 RECURSIVE = YES
-FILE_PATTERNS = *.h *.hpp *.md
+FILE_PATTERNS = *.h *.hpp *.md *.dox
 EXAMPLE_PATH = src-other
 EXAMPLE_PATTERNS = *.cpp
 

--- a/example/src/Documenation/usage.dox
+++ b/example/src/Documenation/usage.dox
@@ -1,0 +1,21 @@
+/**
+\page usage Usage
+\tableofcontents
+
+\section Audio Manager
+Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore
+magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd
+gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing
+elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos
+et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor
+sit amet.
+
+\subsection Troubleshooting
+Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore
+magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd
+gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing
+elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos
+et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor
+sit amet.
+
+*/

--- a/src/Doxybook/TextMarkdownPrinter.cpp
+++ b/src/Doxybook/TextMarkdownPrinter.cpp
@@ -39,37 +39,37 @@ void Doxybook2::TextMarkdownPrinter::print(PrintData& data,
         }
         case XmlTextParser::Node::Type::SECT1: {
             newline();
-            data.ss << "# ";
+            data.ss << "## ";
             data.eol = false;
             break;
         }
         case XmlTextParser::Node::Type::SECT2: {
             newline();
-            data.ss << "## ";
+            data.ss << "### ";
             data.eol = false;
             break;
         }
         case XmlTextParser::Node::Type::SECT3: {
             newline();
-            data.ss << "### ";
+            data.ss << "#### ";
             data.eol = false;
             break;
         }
         case XmlTextParser::Node::Type::SECT4: {
             newline();
-            data.ss << "#### ";
+            data.ss << "##### ";
             data.eol = false;
             break;
         }
         case XmlTextParser::Node::Type::SECT5: {
             newline();
-            data.ss << "##### ";
+            data.ss << "###### ";
             data.eol = false;
             break;
         }
         case XmlTextParser::Node::Type::SECT6: {
             newline();
-            data.ss << "###### ";
+            data.ss << "####### ";
             data.eol = false;
             break;
         }


### PR DESCRIPTION
Before these changes, the \section command was mapped to the top level heading, # in markdown. But, the top level heading is reserved to the page title. Having multiple top-level headings, leads to problems for instance when using mkdoc together with the material theme. Here, the table of contents will not be shown, if there are multiple top-level headings.