### PR TITLE
Fix handling of long file names and linking classes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -223,9 +223,9 @@ jobs:
       - name: Download Doxygen
         shell: bash
         run: |
-          wget https://netcologne.dl.sourceforge.net/project/doxygen/rel-1.8.17/doxygen-1.8.17.linux.bin.tar.gz
-          tar -xvzf doxygen-1.8.17.linux.bin.tar.gz
-          sudo cp ./doxygen-1.8.17/bin/doxygen /usr/local/bin/doxygen
+          wget https://netcologne.dl.sourceforge.net/project/doxygen/rel-1.9.3/doxygen-1.9.3.linux.bin.tar.gz
+          tar -xvzf doxygen-1.9.3.linux.bin.tar.gz
+          sudo cp ./doxygen-1.9.3/bin/doxygen /usr/local/bin/doxygen
           sudo chmod +x /usr/local/bin/doxygen
 
       - uses: actions/download-artifact@v2

--- a/example/src/Audio/AudioManager.hpp
+++ b/example/src/Audio/AudioManager.hpp
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <array>
+#include <cstdint>
+
 #include "AudioBuffer.hpp"
 
 namespace Engine {
@@ -19,7 +22,7 @@ namespace Engine {
             AudioManager(int numOfChannels = 128);
             ~AudioManager();
 
-            void enque(const AudioBuffer& buffer);
+            void enqueue(const AudioBuffer& buffer);
         };
     } // namespace Audio
 } // namespace Engine

--- a/example/src/Audio/GenericAudioManager.hpp
+++ b/example/src/Audio/GenericAudioManager.hpp
@@ -1,0 +1,43 @@
+#pragma once
+
+#include <array>
+#include <cstdint>
+
+namespace Engine {
+    namespace Audio {
+        namespace Some{
+            namespace More{
+                namespace Namespace{
+                    template<std::size_t SIZE>
+                    class Frobnicator final
+                    {
+                    };
+                }
+            }
+        }
+
+        /**
+         * @brief A generic audio manager.
+         * @tparam Foo The type of the audio manager implementation.
+         */
+        template<typename Foo>
+        class GenericAudioManager final
+        {
+        };
+
+        /**
+         * @brief A generic audio manager.
+         * @tparam SIZE The size of the internal array.
+         */
+        template<std::size_t SIZE>
+        class GenericAudioManager<Engine::Audio::Some::More::Namespace::Frobnicator<SIZE>> final
+        {
+            std::array<float, SIZE> _values;
+        public:
+            /**
+             * @brief Constructs this instance.
+             */
+            explicit GenericAudioManager(float value);
+        };
+    } // namespace Audio
+} // namespace Engine

--- a/src/Doxybook/Node.cpp
+++ b/src/Doxybook/Node.cpp
@@ -279,12 +279,12 @@ void Doxybook2::Node::finalize(const Config& config,
                         return urlFolderMaker(config, node);
                     }
                 }
-                return urlFolderMaker(config, node) + Utils::stripAnchor(node.refid) + config.linkSuffix +
+                return urlFolderMaker(config, node) + node.refid + config.linkSuffix +
                        anchorMaker(node);
             }
             case Kind::ENUMVALUE: {
                 const auto n = node.parent->parent;
-                return urlFolderMaker(config, *n) + Utils::stripAnchor(n->refid) + config.linkSuffix +
+                return urlFolderMaker(config, *n) + n->refid + config.linkSuffix +
                        anchorMaker(node);
             }
             default: {
@@ -292,7 +292,7 @@ void Doxybook2::Node::finalize(const Config& config,
                 if (node.group) {
                     n = node.group;
                 }
-                return urlFolderMaker(config, *n) + Utils::stripAnchor(n->refid) + config.linkSuffix +
+                return urlFolderMaker(config, *n) + n->refid + config.linkSuffix +
                        anchorMaker(node);
             }
         }


### PR DESCRIPTION
Under windows, Doxygen shortens long output file names by turning parts of the name, e.g. the template parameters into a hash. When creating links between markdown files, this hash is stripped from URLs, but they were not stripped from the file names while writing the markdown to disk. This PR tries to fix this by not stripping anchors from ref-IDs.

I tried to include an example, where this is happening. I happens only on Windows, maybe due to restrictions on the length of the filename.

Edit: I updated to PR to fix the problem at the (from my understanding) right place.