### PR TITLE
Fix missing newline after list

### DIFF
--- a/example/src/Audio/AudioManager.hpp
+++ b/example/src/Audio/AudioManager.hpp
@@ -11,6 +11,10 @@ namespace Engine {
          * * First item
          * * Second item
          * * Third item **with bold text**
+         * 
+         * Followed by some more text and another list:
+         * * First item
+         * * Second item
          * @ingroup Audio
          * @see Audio::AudioBuffer
          */

--- a/src/Doxybook/TextMarkdownPrinter.cpp
+++ b/src/Doxybook/TextMarkdownPrinter.cpp
@@ -397,6 +397,9 @@ void Doxybook2::TextMarkdownPrinter::print(PrintData& data,
         case XmlTextParser::Node::Type::VARIABLELIST:
         case XmlTextParser::Node::Type::ORDEREDLIST: {
             data.lists.pop_back();
+            if (data.lists.empty()) {
+                newline();
+            }
             break;
         }
         case XmlTextParser::Node::Type::LISTITEM: {


### PR DESCRIPTION
When writing a list to markdown, no newline is appended after the last list item. The following paragraph is also not startet with a newline. Thus, the paragraph gets appended to the last list item by most markdown renderers:
![grafik](https://user-images.githubusercontent.com/18651/150303254-81052539-dcd5-4bde-bfa2-9aa4247b12ab.png)

This PR fixes the behaviour:
![grafik](https://user-images.githubusercontent.com/18651/150303490-0cc9956a-3fe7-4786-84fb-4d6ec576864b.png)

