### PR TITLE
Add replaceUnderscoresInAnchors option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,6 +305,7 @@ The following is a list of config properties, their default value, and descripti
 | `fileExt` | `"md"` | The file extension to use when generating markdown files. |
 | `filesFilter` | `[]` | This will filter which files are allowed to be in the output. For example, an array of `[".hpp", ".h"]` will allow only the files that have file extensions `.hpp` or `.h`. When this is empty (by default) then all files are allowed in the output. This also affects `--json` type of output. This does not filter which classes/functions/etc should be extracted from the source files! (For that, use Doxygen's [FILE_PATTERNS](https://www.doxygen.nl/manual/config.html#cfg_file_patterns)) This only affects listing of those files in the output! |
 | `foldersToGenerate` | `["modules", "classes", "files", "pages", "namespaces", "examples"]` | List of folders to create. You can use this to skip generation of some folders, for example you don't want `examples` then remove it from the array. Note, this does not change the name of the folders that will be generated, this only enables them. This is an enum and must be lower case. If you do not set this value in your JSON config file then all of the folders are created. An empty array will not generate anything at all.' |
+| `replaceUnderscoresInAnchors` | `true` | Replace '_' with '-' in anchors. |
 
 The following are a list of config properties that specify the names of the folders. Each folder holds specific group of C++ stuff. Note that the `Classes` folder also holds interfaces, structs, and unions.
 

--- a/include/Doxybook/Config.hpp
+++ b/include/Doxybook/Config.hpp
@@ -110,6 +110,9 @@ namespace Doxybook2 {
         std::string formulaInlineEnd{"\\)"};
         std::string formulaBlockStart{"\\["};
         std::string formulaBlockEnd{"\\]"};
+
+        // Replace underscores with hyphens in anchors?
+        bool replaceUnderscoresInAnchors{true};
     };
 
     void loadConfig(Config& config, const std::string& path);

--- a/include/Doxybook/Utils.hpp
+++ b/include/Doxybook/Utils.hpp
@@ -45,7 +45,7 @@ namespace Doxybook2 {
         extern std::string escape(std::string str);
         extern std::string title(std::string str);
         extern std::string toLower(std::string str);
-        extern std::string safeAnchorId(std::string str);
+        extern std::string safeAnchorId(std::string str, bool replaceUnderscores);
         extern std::string date(const std::string& format);
         extern std::string stripNamespace(const std::string& format);
         extern std::string stripAnchor(const std::string& str);

--- a/src/Doxybook/Config.cpp
+++ b/src/Doxybook/Config.cpp
@@ -79,6 +79,7 @@ static const std::vector<ConfigArg> CONFIG_ARGS = {
     ConfigArg(&Doxybook2::Config::formulaInlineEnd, "formulaInlineEnd"),
     ConfigArg(&Doxybook2::Config::formulaBlockStart, "formulaBlockStart"),
     ConfigArg(&Doxybook2::Config::formulaBlockEnd, "formulaBlockEnd"),
+    ConfigArg(&Doxybook2::Config::replaceUnderscoresInAnchors, "replaceUnderscoresInAnchors"),
 };
 
 void Doxybook2::loadConfig(Config& config, const std::string& path) {

--- a/src/Doxybook/Node.cpp
+++ b/src/Doxybook/Node.cpp
@@ -244,9 +244,9 @@ void Doxybook2::Node::finalize(const Config& config,
 #endif
     }
 
-    static const auto anchorMaker = [](const Node& node) {
+    static const auto anchorMaker = [](const Config& config, const Node& node) {
         if (!node.isStructured() && node.kind != Kind::MODULE) {
-            return "#" + Utils::toLower(toStr(node.kind)) + "-" + Utils::safeAnchorId(node.name);
+            return "#" + Utils::toLower(toStr(node.kind)) + "-" + Utils::safeAnchorId(node.name, config.replaceUnderscoresInAnchors);
         } else {
             return std::string("");
         }
@@ -280,12 +280,12 @@ void Doxybook2::Node::finalize(const Config& config,
                     }
                 }
                 return urlFolderMaker(config, node) + Utils::stripAnchor(node.refid) + config.linkSuffix +
-                       anchorMaker(node);
+                       anchorMaker(config, node);
             }
             case Kind::ENUMVALUE: {
                 const auto n = node.parent->parent;
                 return urlFolderMaker(config, *n) + Utils::stripAnchor(n->refid) + config.linkSuffix +
-                       anchorMaker(node);
+                       anchorMaker(config, node);
             }
             default: {
                 auto* n = node.parent;
@@ -293,7 +293,7 @@ void Doxybook2::Node::finalize(const Config& config,
                     n = node.group;
                 }
                 return urlFolderMaker(config, *n) + Utils::stripAnchor(n->refid) + config.linkSuffix +
-                       anchorMaker(node);
+                       anchorMaker(config, node);
             }
         }
     };
@@ -311,7 +311,7 @@ void Doxybook2::Node::finalize(const Config& config,
         summary = plainPrinter.print(temp->brief);
         temp.reset();
 
-        anchor = anchorMaker(*this);
+        anchor = anchorMaker(config, *this);
         url = urlMaker(config, *this);
         if (config.linkLowercase)
             url = Utils::toLower(url);

--- a/src/Doxybook/Utils.cpp
+++ b/src/Doxybook/Utils.cpp
@@ -61,10 +61,13 @@ extern std::string Doxybook2::Utils::toLower(std::string str) {
     return str;
 }
 
-std::string Doxybook2::Utils::safeAnchorId(std::string str) {
+std::string Doxybook2::Utils::safeAnchorId(std::string str, bool replaceUnderscores) {
     str = replaceAll(toLower(std::move(str)), "::", "");
     str = replaceAll(str, " ", "-");
-    return replaceAll(str, "_", "-");
+    if (replaceUnderscores) {
+        str = replaceAll(str, "_", "-");
+    }
+    return str;
 }
 
 std::string Doxybook2::Utils::date(const std::string& format) {


### PR DESCRIPTION
Hello,

this PR fixes #82. The replacement of underscores with hyphens can now be switched off via a configuration value to ensure that links are working with mkdocs.