### PR TITLE
Fix pipe in enum member details

### DIFF
--- a/src/Doxybook/DefaultTemplates.cpp
+++ b/src/Doxybook/DefaultTemplates.cpp
@@ -618,7 +618,7 @@ template <{% for param in templateParams %}{{param.typePlain}} {{param.name}}{% 
 | Enumerator | Value | Description |
 | ---------- | ----- | ----------- |
 {% for enumvalue in enumvalues %}| {{enumvalue.name}} | {% if existsIn(enumvalue, "initializer") -%}
-{{replace(enumvalue.initializer, "= ", "")}}{% endif -%}
+{{replace(replace(enumvalue.initializer, "= ", ""), "|", "\\|"))}}{% endif -%}
 | {% if existsIn(enumvalue, "brief") %}{{enumvalue.brief}}{% endif %} {% if existsIn(enumvalue, "details") %}{{enumvalue.details}}{% endif %} |
 {% endfor %}
 {% endif -%}


### PR DESCRIPTION
Enum values in C++ may be defined by combining multiple other values.

E.g.:
``` cpp
enum class Test {
  None = 0x0,
  A = 0x1,
  B = 0x2,
  C = 0x4,
  All = A | B | C
};
```

Due to the use of the pipe `|`, this will break the table layout for the
description of the enum.
Fix this by escaping any pipes found in the JSON.